### PR TITLE
Android N with Jack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ dist: precise
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
 
 android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.0.2
+    - build-tools-24.0.3
     - android-22
     - android-23
+    - android-24
     - extra-google-m2repository
     - extra-android-m2repository
     - extra-android-support
@@ -32,6 +32,8 @@ env:
     - ANDROID_EMULATOR=android-19 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-19
     - ANDROID_EMULATOR=android-21 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-21
     - ANDROID_EMULATOR=android-22 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-22
+    - ANDROID_EMULATOR=android-23 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-23
+    - ANDROID_EMULATOR=android-24 ANDROID_ABI=armeabi-v7a ANDROID_PKGS=sys-img-armeabi-v7a-android-24
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,6 @@ license {
 }
 
 dependencies {
-    compile 'com.feedhenry:fh-android-sdk:3.1.0'
+    compile 'com.feedhenry:fh-android-sdk:3.2.0'
     compile 'com.android.support:appcompat-v7:24.2.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,15 +5,24 @@ plugins {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.3"
 
     defaultConfig {
         applicationId "org.feedhenry.blank"
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
+
+        jackOptions {
+            enabled true
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {
@@ -33,8 +42,6 @@ android {
     }
 }
 
-
-
 license {
     header rootProject.file('misc/HEADER')
     strictCheck true
@@ -42,5 +49,5 @@ license {
 
 dependencies {
     compile 'com.feedhenry:fh-android-sdk:3.1.0'
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:24.2.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Related Jiras:
- [FH-2817](https://issues.jboss.org/browse/FH-2817) - Update fh-android-sdk dependency in all Android template for 3.2.0
- [FH-2705](https://issues.jboss.org/browse/FH-2705) - Update Android Plugin for Gradle on templates
- [FH-2735](https://issues.jboss.org/browse/FH-2735) - Update templates to target Android N 
- [FH-2737](https://issues.jboss.org/browse/FH-2737) - Update templates to use Jack
